### PR TITLE
Add metafeed signature type

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ String encoding of a classic blob id:
  | format code   | format            | specification               |
  | ------------- | ----------------- | --------------------------- |
  | 0             | ed25519           |                             |
+ | 3             | metafeed          | [metafeed]                  |
 
 Example: 
 


### PR DESCRIPTION
@cryptix I noticed this was missing. I wonder if we should include 1 & 2 for gabby & bamboo? 